### PR TITLE
Fix enums not being marshalled correctly

### DIFF
--- a/UE4SSDotNetFramework/Framework/Framework.cs
+++ b/UE4SSDotNetFramework/Framework/Framework.cs
@@ -361,7 +361,22 @@ namespace UE4SSDotNetFramework.Framework
 				var offset = Function.GetOffsetOfParam(function.Pointer, entry.name.StringToBytes());
 				var paramSize = Function.GetSizeOfParam(function.Pointer, entry.name.StringToBytes());
 				var memory = Marshal.AllocHGlobal(paramSize);
-				Marshal.StructureToPtr(entry.value, memory, true);
+
+                if (entry.value is Enum)
+                {
+                    object value = paramSize switch
+                    {
+                        1 => Convert.ToByte(entry.value),
+                        2 => Convert.ToInt16(entry.value),
+                        4 => Convert.ToInt32(entry.value),
+                        _ => Convert.ToInt64(entry.value),
+                    };
+                    Marshal.StructureToPtr(value, memory, true);
+                }
+                else
+                {
+					Marshal.StructureToPtr(entry.value, memory, true);
+                }
 			    
 				Buffer.MemoryCopy((void*)memory, (void*)(paramsPtr + offset), size - offset, paramSize);
 			}


### PR DESCRIPTION
Before enums would be marshalled to their string values making them not work at all. This fix marshals them to their integer values based off of the size provided by the function.

I've only tested this with enums of size 1 but I don't see why it wouldn't work with larger ones.